### PR TITLE
cartesian_nd and modifications for nested matrices and vectors

### DIFF
--- a/named_arrays/__init__.py
+++ b/named_arrays/__init__.py
@@ -6,12 +6,14 @@ from ._scalars.uncertainties.uncertainties import *
 from ._vectors.vectors import *
 from ._vectors.cartesian.vectors_cartesian import *
 from ._vectors.cartesian.vectors_cartesian_2d import *
+from ._vectors.cartesian.vectors_cartesian_nd import *
 from ._vectors.vectors_spectral import *
 from ._vectors.vectors_position import *
 from ._vectors.vectors_spectral_position import *
 from ._matrices.matrices import *
 from ._matrices.cartesian.matrices_cartesian import *
 from ._matrices.cartesian.matrices_cartesian_2d import *
+from ._matrices.cartesian.matrices_cartesian_nd import *
 from ._matrices.matrices_spectral import *
 from ._matrices.matrices_position import *
 from ._matrices.matrices_spectral_position import *

--- a/named_arrays/_matrices/cartesian/matrices_cartesian_2d.py
+++ b/named_arrays/_matrices/cartesian/matrices_cartesian_2d.py
@@ -40,9 +40,6 @@ class AbstractCartesian2dMatrixArray(
     def type_explicit(self) -> Type[Cartesian2dMatrixArray]:
         return Cartesian2dMatrixArray
 
-    @property
-    def cartesian_nd(self):
-        return NotImplementedError
 
 
     @property

--- a/named_arrays/_matrices/cartesian/matrices_cartesian_nd.py
+++ b/named_arrays/_matrices/cartesian/matrices_cartesian_nd.py
@@ -41,6 +41,6 @@ class AbstractCartesianNdMatrixArray(
 class CartesianNdMatrixArray(
     na.CartesianNdVectorArray,
     AbstractCartesianNdMatrixArray,
-    na.AbstractExplicitMatrixArray,
+    na.AbstractExplicitCartesianMatrixArray,
 ):
     pass

--- a/named_arrays/_matrices/cartesian/matrices_cartesian_nd.py
+++ b/named_arrays/_matrices/cartesian/matrices_cartesian_nd.py
@@ -1,3 +1,6 @@
+from __future__ import annotations
+from typing import TypeVar, Generic, Type
+import abc
 import dataclasses
 import named_arrays as na
 
@@ -10,13 +13,34 @@ __all__ = [
 @dataclasses.dataclass(eq=False, repr=False)
 class AbstractCartesianNdMatrixArray(
     na.AbstractCartesianMatrixArray,
+    na.AbstractCartesianNdVectorArray,
 ):
-    pass
+
+    @property
+    def type_abstract(self) -> Type[AbstractCartesianNdMatrixArray]:
+        return AbstractCartesianNdMatrixArray
+
+    @property
+    def type_explicit(self) -> Type[CartesianNdMatrixArray]:
+        return CartesianNdMatrixArray
+
+    @property
+    def type_vector(self) -> Type[na.CartesianNdVectorArray]:
+        return na.CartesianNdVectorArray
+
+    @property
+    def determinant(self) -> na.ScalarLike:
+        return NotImplementedError
+
+    @property
+    def inverse(self) -> na.AbstractMatrixArray:
+        return NotImplementedError
 
 
 @dataclasses.dataclass(eq=False, repr=False)
 class CartesianNdMatrixArray(
+    na.CartesianNdVectorArray,
     AbstractCartesianNdMatrixArray,
-    na.AbstractExplicitCartesianMatrixArray,
+    na.AbstractExplicitMatrixArray,
 ):
     pass

--- a/named_arrays/_matrices/cartesian/tests/test_matrices_cartesian_2d.py
+++ b/named_arrays/_matrices/cartesian/tests/test_matrices_cartesian_2d.py
@@ -24,7 +24,6 @@ class AbstractTestAbstractCartesian2dMatrixArray(
 
 
 def _cartesian_2d_matrices():
-
     arrays_xx = [
         4,
         na.ScalarUniformRandomSample(-4, 4, shape_random=dict(y=_num_y)),
@@ -56,11 +55,31 @@ def _cartesian_2d_matrices():
         for unit in units
     ]
 
+    matrices.append(
+        na.Cartesian2dMatrixArray(
+            x=na.Cartesian2dMatrixArray(
+                x=na.Cartesian2dMatrixArray(
+                    x=na.Cartesian2dVectorArray(x=1, y=2),
+                    y=na.Cartesian2dVectorArray(x=1, y=2)),
+                y=na.Cartesian2dMatrixArray(
+                    x=na.Cartesian2dVectorArray(x=1, y=2),
+                    y=na.Cartesian2dVectorArray(x=1, y=2)),
+            ),
+            y=na.Cartesian2dMatrixArray(
+                x=na.Cartesian2dMatrixArray(
+                    x=na.Cartesian2dVectorArray(x=1, y=2),
+                    y=na.Cartesian2dVectorArray(x=1, y=2)),
+                y=na.Cartesian2dMatrixArray(
+                    x=na.Cartesian2dVectorArray(x=1, y=2),
+                    y=na.Cartesian2dVectorArray(x=1, y=2)),
+            ),
+        )
+    )
+
     return matrices
 
 
 def _cartesian_2d_matrices_2():
-
     arrays_xx = [
         6,
         na.ScalarUniformRandomSample(-6, 6, shape_random=dict(y=_num_y)),
@@ -104,6 +123,28 @@ def _cartesian_2d_matrices_2():
         for array_yy in arrays_yy
         for unit in units
     ]
+
+    matrices.append(
+        na.Cartesian2dMatrixArray(
+            x=na.Cartesian2dMatrixArray(
+                x=na.Cartesian2dMatrixArray(
+                    x=na.Cartesian2dVectorArray(x=1, y=2),
+                    y=na.Cartesian2dVectorArray(x=1, y=2)),
+                y=na.Cartesian2dMatrixArray(
+                    x=na.Cartesian2dVectorArray(x=1, y=2),
+                    y=na.Cartesian2dVectorArray(x=1, y=2)),
+            ),
+            y=na.Cartesian2dMatrixArray(
+                x=na.Cartesian2dMatrixArray(
+                    x=na.Cartesian2dVectorArray(x=1, y=2),
+                    y=na.Cartesian2dVectorArray(x=1, y=2)),
+                y=na.Cartesian2dMatrixArray(
+                    x=na.Cartesian2dVectorArray(x=1, y=2),
+                    y=na.Cartesian2dVectorArray(x=1, y=2)),
+            ),
+        )
+    )
+
 
     return scalars + matrices
 
@@ -187,8 +228,3 @@ class TestCartesian2dMatrixArray(
         test_matrices_cartesian.AbstractTestAbstractCartesianMatrixArray.TestMatmul
     ):
         pass
-
-
-
-
-

--- a/named_arrays/_matrices/matrices.py
+++ b/named_arrays/_matrices/matrices.py
@@ -42,7 +42,7 @@ class AbstractMatrixArray(
                 for c in row.components:
                     result[(r, c)] = row.components[c]
             else:
-                result[(r, '')] = row
+                result[(r,)] = row
 
         return result
 
@@ -170,7 +170,7 @@ class AbstractMatrixArray(
         """
 
     @property
-    def cartesian_nd(self):
+    def cartesian_nd(self) -> na.AbstractCartesianNdMatrixArray:
         """
         Convert all cartesian vectors making up the matrix to instances of :class:`AbstractCartesianNdVectorArray`
         """
@@ -266,7 +266,8 @@ class AbstractExplicitMatrixArray(
         self.__dict__ = value
 
     @classmethod
-    def from_cartesian_nd(cls: AbstractExplicitMatrixArray, array: na.CartesianNdMatrixArray,
+    def from_cartesian_nd(cls: AbstractExplicitMatrixArray,
+                          array: na.CartesianNdMatrixArray,
                           like: None | AbstractExplicitMatrixArray = None) -> AbstractExplicitMatrixArray:
 
         if like is None:

--- a/named_arrays/_matrices/matrices.py
+++ b/named_arrays/_matrices/matrices.py
@@ -33,7 +33,7 @@ class AbstractMatrixArray(
         return super().components
 
     @property
-    def entries(self) -> dict[tuple[str, str], na.ScalarLike]:
+    def entries(self) -> dict[tuple[str, ...], na.ScalarLike]:
         rows = self.cartesian_nd.rows
         result = {}
         for r in rows:
@@ -266,9 +266,11 @@ class AbstractExplicitMatrixArray(
         self.__dict__ = value
 
     @classmethod
-    def from_cartesian_nd(cls: AbstractExplicitMatrixArray,
-                          array: na.CartesianNdMatrixArray,
-                          like: None | AbstractExplicitMatrixArray = None) -> AbstractExplicitMatrixArray:
+    def from_cartesian_nd(
+        cls: AbstractExplicitMatrixArray,
+        array: na.CartesianNdMatrixArray,
+        like: None | AbstractExplicitMatrixArray = None
+    ) -> AbstractExplicitMatrixArray:
 
         if like is None:
             components_new = array.components

--- a/named_arrays/_matrices/matrices.py
+++ b/named_arrays/_matrices/matrices.py
@@ -182,6 +182,36 @@ class AbstractExplicitMatrixArray(
     def components(self, value: dict[str, na.AbstractVectorArray]):
         self.__dict__ = value
 
+    @classmethod
+    def from_cartesian_nd(
+            cls: AbstractExplicitMatrixArray,
+            cartesian_nd: na.CartesianNdMatrixArray,
+            like: None | AbstractExplicitMatrixArray = None,
+    ) -> AbstractExplicitMatrixArray:
+
+        if like is None:
+            components_new = cartesian_nd.components
+
+        else:
+            nd_components = cartesian_nd.components
+            components_new = {}
+            components = like.components
+            for c in components:
+
+                component = components[c]
+                if isinstance(component, na.AbstractMatrixArray):
+                    secondary_components = {}
+                    for c2 in component.components:
+                        component2 = component.components[c2]
+                        secondary_components[c2] = component2.type_explicit.from_cartesian_nd(nd_components[f"{c}_{c2}"],
+                                                                                              like=component2)
+
+                    components_new[c] = component.type_explicit.from_components(secondary_components)
+                else:
+                    components_new[c] = component
+
+        return cls.from_components(components_new)
+
 
 @dataclasses.dataclass(eq=False, repr=False)
 class AbstractImplicitMatrixArray(

--- a/named_arrays/_matrices/matrices.py
+++ b/named_arrays/_matrices/matrices.py
@@ -70,7 +70,7 @@ class AbstractMatrixArray(
             return False
 
     @property
-    def vector(self):
+    def vector(self) -> na.AbstractExplicitVectorArray:
         new_dict = {}
         for c in self.components:
             component = self.components[c]
@@ -84,12 +84,10 @@ class AbstractMatrixArray(
     def matrix(self):
         return self
 
-
-
     @property
-    def prototype_row(self):
+    def prototype_row(self) -> na.AbstractVectorArray:
         """
-        Return a vector of the same type as each row of the matrix with each component zeroed.
+        Return a vector of the same type as each row of the matrix.
         """
         rows = self.rows
         if not self.is_consistent:
@@ -102,13 +100,12 @@ class AbstractMatrixArray(
         if isinstance(prototype_row, AbstractMatrixArray):
             prototype_row = prototype_row.prototype_row
 
-
         return prototype_row
 
     @property
-    def prototype_column(self):
+    def prototype_column(self) -> na.AbstractMatrixArray:
         """
-        Return a vector of the same type of each column of the matrix with each component zeroed.
+        Return a matrix of the same type as each column of the matrix with each component zeroed.
         """
         column_dict = {}
         for c in self.components:
@@ -135,8 +132,6 @@ class AbstractMatrixArray(
 
         return self.type_explicit.from_components(new_dict)
 
-
-
     @property
     def matrix_transpose(self):
         rows = self.rows
@@ -149,7 +144,6 @@ class AbstractMatrixArray(
 
         row_prototype = self.prototype_row
         column_prototype = self.prototype_column
-
 
         prototype_matrix_transpose = row_prototype.matrix.prototype_matrix(column_prototype.vector)
 
@@ -293,7 +287,7 @@ class AbstractExplicitMatrixArray(
                     nd_key_mod = f"{c}_"
                     sub_dict = {k[len(nd_key_mod):]: v for k, v in nd_components.items() if k.startswith(nd_key_mod)}
                     components_new[c] = component.type_explicit.from_cartesian_nd(na.CartesianNdMatrixArray(sub_dict),
-                                                                                                            like=component)
+                                                                                  like=component)
                 else:
                     components_new[c] = component.type_explicit.from_cartesian_nd(
                         nd_components[c],

--- a/named_arrays/_matrices/matrices.py
+++ b/named_arrays/_matrices/matrices.py
@@ -79,7 +79,10 @@ class AbstractMatrixArray(
             )
         type_matrix = row_prototype.type_matrix
         type_row = self.type_vector
-        result = type_matrix.from_components({c: type_row() for c in row_prototype.components})
+        # row_dict = {c: type_row() for c in row_prototype.components}
+        row_dict = {c: type_row.from_components(dict.fromkeys(row_prototype.components, 0)) for c in
+                    row_prototype.components}
+        result = type_matrix.from_components(row_dict)
 
         for r in rows:
             for c in rows[r].components:
@@ -101,11 +104,29 @@ class AbstractMatrixArray(
         The inverse of this matrix
         """
 
+    @property
+    def cartesian_nd(self):
+        """
+        Convert all cartesian vectors making up the matrix to instances of :class:`AbstractCartesianNdVectorArray`
+        """
+        components_new = dict()
+        components = self.components
+        for c in components:
+            component = components[c]
+
+            if isinstance(component, na.AbstractMatrixArray):
+                for c2 in component.components:
+                    components_new[f"{c}_{c2}"] = component.components[c2].cartesian_nd
+            else:
+                components_new[c] = component.cartesian_nd
+
+        return na.CartesianNdMatrixArray(components_new)
+
     def __array_matmul__(
             self,
             x1: na.ArrayLike,
             x2: na.ArrayLike,
-            out: tuple[None | na.AbstractExplicitArray] = (None, ),
+            out: tuple[None | na.AbstractExplicitArray] = (None,),
             **kwargs,
     ) -> na.AbstractExplicitArray:
 

--- a/named_arrays/_matrices/matrices.py
+++ b/named_arrays/_matrices/matrices.py
@@ -267,7 +267,7 @@ class AbstractExplicitMatrixArray(
 
     @classmethod
     def from_cartesian_nd(
-        cls: AbstractExplicitMatrixArray,
+        cls,
         array: na.CartesianNdMatrixArray,
         like: None | AbstractExplicitMatrixArray = None
     ) -> AbstractExplicitMatrixArray:

--- a/named_arrays/_matrices/matrices_position.py
+++ b/named_arrays/_matrices/matrices_position.py
@@ -34,11 +34,6 @@ class AbstractPositionMatrixArray(
         return PositionMatrixArray
 
     @property
-    def cartesian_nd(self):
-        return NotImplementedError
-
-
-    @property
     def type_vector(self) -> Type[na.PositionVectorArray]:
         return na.PositionVectorArray
 

--- a/named_arrays/_matrices/matrices_spectral.py
+++ b/named_arrays/_matrices/matrices_spectral.py
@@ -34,11 +34,6 @@ class AbstractSpectralMatrixArray(
         return SpectralMatrixArray
 
     @property
-    def cartesian_nd(self):
-        return NotImplementedError
-
-
-    @property
     def type_vector(self) -> Type[na.SpectralVectorArray]:
         return na.SpectralVectorArray
 

--- a/named_arrays/_matrices/matrices_spectral_position.py
+++ b/named_arrays/_matrices/matrices_spectral_position.py
@@ -30,11 +30,6 @@ class AbstractSpectralPositionMatrixArray(
         return na.SpectralPositionVectorArray
 
     @property
-    def cartesian_nd(self):
-        return NotImplementedError
-
-
-    @property
     def determinant(self) -> na.ScalarLike:
         return NotImplementedError
 

--- a/named_arrays/_matrices/tests/test_matrices.py
+++ b/named_arrays/_matrices/tests/test_matrices.py
@@ -33,11 +33,6 @@ class AbstractTestAbstractMatrixArray(
     def test_is_square(self, array: na.AbstractMatrixArray):
         assert array.is_square == (len(array.row_prototype.entries) == len(array.column_prototype.entries))
 
-    def all_vectors(array: na.AbstractVectorArray):
-        """
-        Return True if every component is an instance of `na.AbstractVectorArray`.
-        """
-
     def test_cartesian_nd(self, array: na.AbstractMatrixArray):
         cartesian_nd = array.cartesian_nd
         assert isinstance(cartesian_nd, na.AbstractCartesianNdMatrixArray)

--- a/named_arrays/_matrices/tests/test_matrices.py
+++ b/named_arrays/_matrices/tests/test_matrices.py
@@ -31,7 +31,7 @@ class AbstractTestAbstractMatrixArray(
         assert not array_2.is_consistent
 
     def test_is_square(self, array: na.AbstractMatrixArray):
-        assert array.is_square
+        assert array.is_square == (len(array.prototype_row.entries) == len(array.prototype_column.entries))
 
     def test_matrix_transpose(self, array: na.AbstractMatrixArray):
         result = array.matrix_transpose
@@ -54,7 +54,7 @@ class AbstractTestAbstractMatrixArray(
 
             assert isinstance(result, (float, complex, u.Quantity, na.AbstractScalar))
 
-            assert np.all((2**2) * result == (2 * array).determinant)
+            assert np.all((2 ** 2) * result == (2 * array).determinant)
             assert np.all(result == array.matrix_transpose.determinant)
             assert np.allclose(result * result, (array @ array).determinant)
             assert np.allclose(result, 1 / array.inverse.determinant)
@@ -93,7 +93,6 @@ class AbstractTestAbstractMatrixArray(
                 with pytest.raises(TypeError):
                     array @ array_2
                 return
-
 
 
 class AbstractTestAbstractExplicitMatrixArray(

--- a/named_arrays/_matrices/tests/test_matrices.py
+++ b/named_arrays/_matrices/tests/test_matrices.py
@@ -31,7 +31,24 @@ class AbstractTestAbstractMatrixArray(
         assert not array_2.is_consistent
 
     def test_is_square(self, array: na.AbstractMatrixArray):
-        assert array.is_square == (len(array.prototype_row.entries) == len(array.prototype_column.entries))
+        assert array.is_square == (len(array.row_prototype.entries) == len(array.column_prototype.entries))
+
+    def all_vectors(array: na.AbstractVectorArray):
+        """
+        Return True if every component is an instance of `na.AbstractVectorArray`.
+        """
+
+    def test_cartesian_nd(self, array: na.AbstractMatrixArray):
+        cartesian_nd = array.cartesian_nd
+        assert isinstance(cartesian_nd, na.AbstractCartesianNdMatrixArray)
+        for c in cartesian_nd.components:
+            component = cartesian_nd.components[c]
+            assert isinstance(component, na.AbstractCartesianNdVectorArray)
+            for c2 in component.components:
+                assert isinstance(na.as_named_array(component.components[c2]), na.AbstractScalar)
+
+    def test_from_cartesian_nd(self, array: na.AbstractMatrixArray):
+        assert np.all(array.type_explicit.from_cartesian_nd(array.cartesian_nd, like=array) == array)
 
     def test_matrix_transpose(self, array: na.AbstractMatrixArray):
         result = array.matrix_transpose
@@ -41,12 +58,15 @@ class AbstractTestAbstractMatrixArray(
 
         assert np.all(result.matrix_transpose == array)
         assert np.all(result + result == (array + array).matrix_transpose)
-        if array.prototype_row.cartesian_nd.components.keys() == array.prototype_column.cartesian_nd.components.keys():
+        if array.row_prototype.cartesian_nd.components.keys() == array.column_prototype.cartesian_nd.components.keys():
             assert np.all(result @ result == (array @ array).matrix_transpose)
         assert np.all(2 * result == (2 * array).matrix_transpose)
         if array.is_square:
             assert np.all(result.determinant == array.determinant)
             assert np.all(result.inverse == (array.inverse).matrix_transpose)
+
+    def test_matrix(self, array: na.AbstractMatrixArray):
+        assert np.all(array.matrix == array)
 
     def test_determinant(self, array: na.AbstractMatrixArray):
         if array.is_square:

--- a/named_arrays/_matrices/tests/test_matrices.py
+++ b/named_arrays/_matrices/tests/test_matrices.py
@@ -41,34 +41,38 @@ class AbstractTestAbstractMatrixArray(
 
         assert np.all(result.matrix_transpose == array)
         assert np.all(result + result == (array + array).matrix_transpose)
-        assert np.all(result @ result == (array @ array).matrix_transpose)
+        if array.prototype_row.cartesian_nd.components.keys() == array.prototype_column.cartesian_nd.components.keys():
+            assert np.all(result @ result == (array @ array).matrix_transpose)
         assert np.all(2 * result == (2 * array).matrix_transpose)
-        assert np.all(result.determinant == array.determinant)
-        assert np.all(result.inverse == (array.inverse).matrix_transpose)
+        if array.is_square:
+            assert np.all(result.determinant == array.determinant)
+            assert np.all(result.inverse == (array.inverse).matrix_transpose)
 
     def test_determinant(self, array: na.AbstractMatrixArray):
-        result = array.determinant
+        if array.is_square:
+            result = array.determinant
 
-        assert isinstance(result, (float, complex, u.Quantity, na.AbstractScalar))
+            assert isinstance(result, (float, complex, u.Quantity, na.AbstractScalar))
 
-        assert np.all((2**2) * result == (2 * array).determinant)
-        assert np.all(result == array.matrix_transpose.determinant)
-        assert np.allclose(result * result, (array @ array).determinant)
-        assert np.allclose(result, 1 / array.inverse.determinant)
+            assert np.all((2**2) * result == (2 * array).determinant)
+            assert np.all(result == array.matrix_transpose.determinant)
+            assert np.allclose(result * result, (array @ array).determinant)
+            assert np.allclose(result, 1 / array.inverse.determinant)
 
     def test_inverse(self, array: na.AbstractMatrixArray):
-        result = array.inverse
+        if array.is_square:
+            result = array.inverse
 
-        assert isinstance(result, na.AbstractMatrixArray)
+            assert isinstance(result, na.AbstractMatrixArray)
 
-        identity = na.Cartesian2dMatrixArray(
-            x=na.Cartesian2dVectorArray(1, 0),
-            y=na.Cartesian2dVectorArray(0, 1),
-        )
+            identity = na.Cartesian2dMatrixArray(
+                x=na.Cartesian2dVectorArray(1, 0),
+                y=na.Cartesian2dVectorArray(0, 1),
+            )
 
-        assert np.allclose(array @ result, identity)
-        assert np.allclose(result.inverse, array)
-        assert np.allclose((2 * array).inverse, result / 2)
+            assert np.allclose(array @ result, identity)
+            assert np.allclose(result.inverse, array)
+            assert np.allclose((2 * array).inverse, result / 2)
 
     class TestMatmul(
         named_arrays._vectors.tests.test_vectors.AbstractTestAbstractVectorArray.TestMatmul
@@ -79,10 +83,17 @@ class AbstractTestAbstractMatrixArray(
                 array: float | u.Quantity | na.AbstractScalar | na.AbstractVectorArray | na.AbstractMatrixArray,
                 array_2: float | u.Quantity | na.AbstractScalar | na.AbstractVectorArray | na.AbstractMatrixArray,
         ):
-            assert np.all(array @ (array_2 + array_2) == array @ array_2 + array @ array_2)
-            assert np.all((array + array) @ array_2 == array @ array_2 + array @ array_2)
-            assert np.all(2 * (array @ array_2) == (2 * array) @ array_2)
-            assert np.all((array @ array_2) * 2 == array @ (array_2 * 2))
+            try:
+                assert np.all(array @ (array_2 + array_2) == array @ array_2 + array @ array_2)
+                assert np.all((array + array) @ array_2 == array @ array_2 + array @ array_2)
+                assert np.all(2 * (array @ array_2) == (2 * array) @ array_2)
+                assert np.all((array @ array_2) * 2 == array @ (array_2 * 2))
+
+            except TypeError:
+                with pytest.raises(TypeError):
+                    array @ array_2
+                return
+
 
 
 class AbstractTestAbstractExplicitMatrixArray(

--- a/named_arrays/_vectors/cartesian/tests/test_vectors_cartesian.py
+++ b/named_arrays/_vectors/cartesian/tests/test_vectors_cartesian.py
@@ -65,7 +65,7 @@ class AbstractTestAbstractCartesianVectorArray(
                 elif ufunc in [np.log1p]:
                     kwargs["where"] = array >= -1
                 elif ufunc in [np.arcsin, np.arccos, np.arctanh]:
-                    kwargs["where"] = (-1< array) & (array < 1)
+                    kwargs["where"] = (-1 < array) & (array < 1)
                 elif ufunc in [np.arccosh]:
                     kwargs["where"] = array >= 1
                 elif ufunc in [np.reciprocal]:
@@ -80,12 +80,12 @@ class AbstractTestAbstractCartesianVectorArray(
                     else:
                         kwargs_components[c][k] = kwargs[k]
 
-            result_expected = tuple(array.type_explicit() for _ in range(ufunc.nout))
+            result_expected = tuple(array.prototype_vector for _ in range(ufunc.nout))
             try:
                 for c in components:
                     result_c = ufunc(components[c], **kwargs_components[c])
                     if ufunc.nout == 1:
-                        result_c = (result_c, )
+                        result_c = (result_c,)
                     for i in range(ufunc.nout):
                         result_expected[i].components[c] = result_c[i]
 
@@ -130,10 +130,10 @@ class AbstractTestAbstractCartesianVectorArray(
                 if isinstance(array_2, na.AbstractVectorArray):
                     array_2_normalized = array_2
                 else:
-                    array_2_normalized = array.type_explicit.from_scalar(array_2)
+                    array_2_normalized = array.type_explicit.from_scalar(array_2, like=array)
             else:
                 if isinstance(array_2, na.AbstractVectorArray):
-                    array_normalized = array_2.type_explicit.from_scalar(array)
+                    array_normalized = array_2.type_explicit.from_scalar(array, like=array_2)
                     array_2_normalized = array_2
                 else:
                     raise ValueError("One of the test arrays should be vectors")
@@ -159,8 +159,7 @@ class AbstractTestAbstractCartesianVectorArray(
                     else:
                         kwargs_components[c][k] = kwargs[k]
 
-
-            result_expected = tuple(array_normalized.type_explicit() for _ in range(ufunc.nout))
+            result_expected = tuple(array_normalized.prototype_vector for _ in range(ufunc.nout))
             try:
                 for c in components:
                     result_c = ufunc(components[c], components_2[c], **kwargs_components[c])

--- a/named_arrays/_vectors/cartesian/tests/test_vectors_cartesian.py
+++ b/named_arrays/_vectors/cartesian/tests/test_vectors_cartesian.py
@@ -149,7 +149,7 @@ class AbstractTestAbstractCartesianVectorArray(
                     kwargs["where"] = (array_2 >= 1) & (array >= 0)
                 elif ufunc in [np.divide, np.floor_divide, np.remainder, np.fmod, np.divmod]:
                     kwargs["where"] = array_2 != 0
-            except u.UnitConversionError:
+            except (u.UnitConversionError, TypeError):
                 pass
 
             for c in components:

--- a/named_arrays/_vectors/cartesian/tests/test_vectors_cartesian_2d.py
+++ b/named_arrays/_vectors/cartesian/tests/test_vectors_cartesian_2d.py
@@ -31,6 +31,7 @@ def _cartesian2d_arrays():
     arrays_numeric_x = [
         4,
         na.ScalarUniformRandomSample(-4, 4, shape_random=dict(y=_num_y)),
+        na.Cartesian2dVectorArray(x=2, y=3)
     ]
     units_x = [1, u.mm]
     arrays_numeric_x = [a * unit for a in arrays_numeric_x for unit in units_x]
@@ -42,7 +43,8 @@ def _cartesian2d_arrays():
             nominal=na.ScalarUniformRandomSample(-5, 5, shape_random=dict(x=_num_x, y=_num_y)),
             width=1,
             num_distribution=_num_distribution
-        )
+        ),
+        na.Cartesian2dVectorArray(x=4, y=8)
     ]
     units_y = [1, u.mm]
     arrays_numeric_y = [a * unit for a in arrays_numeric_y for unit in units_y]

--- a/named_arrays/_vectors/cartesian/tests/test_vectors_cartesian_nd.py
+++ b/named_arrays/_vectors/cartesian/tests/test_vectors_cartesian_nd.py
@@ -210,7 +210,12 @@ class TestCartesianNdVectorArray(
         argvalues=[
             0,
             na.ScalarUniformRandomSample(-5, 5, dict(y=_num_y)),
-            # na.Cartesian2dVectorUniformRandomSample(-5, 5, shape_random=dict(y=_num_y)),
+            na.CartesianNdVectorArray(
+                dict(
+                    x=na.ScalarUniformRandomSample(-5, 5, shape_random=dict(y=_num_y)),
+                    y=na.ScalarUniformRandomSample(-5, 5, shape_random=dict(y=_num_y))
+                )
+            ),
         ]
     )
     def test__setitem__(

--- a/named_arrays/_vectors/cartesian/tests/test_vectors_cartesian_nd.py
+++ b/named_arrays/_vectors/cartesian/tests/test_vectors_cartesian_nd.py
@@ -119,7 +119,7 @@ class AbstractTestAbstractCartesianNdVectorArray(
 
     @pytest.mark.parametrize(
         argnames='item',
-        argvalues=_cartesianNd_items()
+        argvalues=_cartesian_nd_items()
     )
     def test__getitem__(
             self,

--- a/named_arrays/_vectors/cartesian/tests/test_vectors_cartesian_nd.py
+++ b/named_arrays/_vectors/cartesian/tests/test_vectors_cartesian_nd.py
@@ -1,0 +1,222 @@
+from typing import Type, Callable, Sequence
+import pytest
+import numpy as np
+import astropy.units as u
+import named_arrays as na
+import named_arrays.tests.test_core
+from . import test_vectors_cartesian
+
+__all__ = [
+    'AbstractTestAbstractCartesianNdVectorArray',
+    'TestCartesianNdVectorArray',
+]
+
+_num_x = named_arrays.tests.test_core.num_x
+_num_y = named_arrays.tests.test_core.num_y
+_num_distribution = named_arrays.tests.test_core.num_distribution
+
+
+def _cartesian_nd_arrays():
+    arrays_numeric_x = [
+        4,
+        na.ScalarUniformRandomSample(-4, 4, shape_random=dict(y=_num_y)),
+        na.Cartesian2dVectorArray(x=2, y=5)
+    ]
+    units_x = [1, u.mm]
+    arrays_numeric_x = [a * unit for a in arrays_numeric_x for unit in units_x]
+
+    arrays_numeric_y = [
+        5.,
+        na.ScalarUniformRandomSample(-5, 5, shape_random=dict(x=_num_x, y=_num_y)),
+        na.UniformUncertainScalarArray(
+            nominal=na.ScalarUniformRandomSample(-5, 5, shape_random=dict(x=_num_x, y=_num_y)),
+            width=1,
+            num_distribution=_num_distribution
+        ),
+        na.Cartesian2dVectorArray(x=7.3, y=5)
+    ]
+    units_y = [1, u.mm]
+    arrays_numeric_y = [a * unit for a in arrays_numeric_y for unit in units_y]
+
+    arrays = [na.CartesianNdVectorArray(
+        components=dict(x=ax, y=ay)) for ax in arrays_numeric_x for ay in arrays_numeric_y
+    ]
+
+    return arrays
+
+
+def _cartesian_nd_arrays_2():
+    units = [1, u.mm]
+    arrays_scalar = [
+        6,
+        na.ScalarArray(6),
+        na.ScalarUniformRandomSample(-6, 6, shape_random=dict(y=_num_y, x=_num_x)),
+        na.UniformUncertainScalarArray(
+            nominal=na.ScalarUniformRandomSample(-6, 6, shape_random=dict(y=_num_y, x=_num_x)),
+            width=1,
+            num_distribution=_num_distribution
+        )
+    ]
+    arrays_scalar = [a * unit for a in arrays_scalar for unit in units]
+    arrays_vector_x = [
+        7,
+        na.ScalarUniformRandomSample(-7, 7, shape_random=dict(y=_num_y)),
+    ]
+    arrays_vector_x = [a * unit for a in arrays_vector_x for unit in units]
+    arrays_vector_y = [
+        8,
+        na.ScalarUniformRandomSample(-8, 8, shape_random=dict(y=_num_y, x=_num_x)),
+    ]
+    arrays_vector_y = [a * unit for a in arrays_vector_y for unit in units]
+    arrays_vector = [na.CartesianNdVectorArray(dict(x=ax, y=ay)) for ax in arrays_vector_x for ay in arrays_vector_y]
+    arrays = arrays_scalar + arrays_vector
+    return arrays
+
+
+def _cartesianNd_items() -> list[na.AbstractArray | dict[str, int, slice, na.AbstractArray]]:
+    return [
+        dict(y=0),
+        dict(y=slice(0, 1)),
+        dict(y=na.ScalarArrayRange(0, 2, axis='y')),
+        dict(
+            y=na.CartesianNdVectorArray(dict(
+                x=na.ScalarArrayRange(0, 2, axis='y'),
+                y=na.ScalarArrayRange(0, 2, axis='y'),
+            ))
+        ),
+        dict(
+            y=na.UncertainScalarArray(
+                nominal=na.ScalarArray(np.array([0, 1]), axes=('y',)),
+                distribution=na.ScalarArray(
+                    ndarray=np.array([[0, ], [1, ]]),
+                    axes=('y', na.UncertainScalarArray.axis_distribution),
+                )
+            ),
+            _distribution=na.UncertainScalarArray(
+                nominal=None,
+                distribution=na.ScalarArray(
+                    ndarray=np.array([[0], [0]]),
+                    axes=('y', na.UncertainScalarArray.axis_distribution),
+                )
+            )
+        ),
+        na.ScalarLinearSpace(0, 1, axis='y', num=_num_y) > 0.5,
+        na.UniformUncertainScalarArray(
+            nominal=na.ScalarLinearSpace(0, 1, axis='y', num=_num_y),
+            width=0.1,
+            num_distribution=_num_distribution,
+        ) > 0.5,
+        na.CartesianNdVectorArray(dict(
+            x=na.ScalarLinearSpace(0, 1, axis='y', num=_num_y) > 0.3,
+            y=na.ScalarLinearSpace(0, 1, axis='y', num=_num_y) > 0.5,
+        )),
+    ]
+
+
+class AbstractTestAbstractCartesianNdVectorArray(
+    test_vectors_cartesian.AbstractTestAbstractCartesianVectorArray,
+):
+
+    @pytest.mark.parametrize(
+        argnames='item',
+        argvalues=_cartesianNd_items()
+    )
+    def test__getitem__(
+            self,
+            array: na.AbstractCartesianNdVectorArray,
+            item: dict[str, int | slice | na.AbstractArray] | na.AbstractArray,
+    ):
+        super().test__getitem__(array=array, item=item)
+
+    @pytest.mark.parametrize('array_2', _cartesian_nd_arrays_2())
+    class TestUfuncBinary(
+        test_vectors_cartesian.AbstractTestAbstractCartesianVectorArray.TestUfuncBinary
+    ):
+        pass
+
+    @pytest.mark.parametrize('array_2', _cartesian_nd_arrays_2())
+    class TestMatmul(
+        test_vectors_cartesian.AbstractTestAbstractCartesianVectorArray.TestMatmul
+    ):
+        pass
+
+    class TestArrayFunctions(
+        test_vectors_cartesian.AbstractTestAbstractCartesianVectorArray.TestArrayFunctions
+    ):
+        @pytest.mark.parametrize(
+            argnames='where',
+            argvalues=[
+                np._NoValue,
+                True,
+                na.ScalarArray(True),
+                (na.ScalarLinearSpace(-1, 1, 'x', _num_x) >= 0) | (na.ScalarLinearSpace(-1, 1, 'y', _num_y) >= 0),
+                na.CartesianNdVectorArray(dict(
+                    x=(na.ScalarLinearSpace(-1, 1, 'x', _num_x) >= 0) | (na.ScalarLinearSpace(-1, 1, 'y', _num_y) >= 0),
+                    y=(na.ScalarLinearSpace(-1, 1, 'x', _num_x) <= 0) | (na.ScalarLinearSpace(-1, 1, 'y', _num_y) <= 0),
+                ))
+            ]
+        )
+        class TestReductionFunctions(
+            test_vectors_cartesian.AbstractTestAbstractCartesianVectorArray.TestArrayFunctions.TestReductionFunctions,
+        ):
+            pass
+
+        @pytest.mark.parametrize(
+            argnames='q',
+            argvalues=[
+                .25,
+                25 * u.percent,
+                na.ScalarLinearSpace(.25, .75, axis='q', num=3, endpoint=True),
+                na.CartesianNdVectorArray(dict(x=25 * u.percent, y=35 * u.percent)),
+                na.CartesianNdVectorArray(dict(
+                    x=na.ScalarLinearSpace(.25, .50, axis='q', num=3, endpoint=True),
+                    y=na.ScalarLinearSpace(50 * u.percent, 75 * u.percent, axis='q', num=3, endpoint=True)
+                ))
+            ]
+        )
+        class TestPercentileLikeFunctions(
+            test_vectors_cartesian.AbstractTestAbstractCartesianVectorArray.TestArrayFunctions.
+            TestPercentileLikeFunctions,
+        ):
+            pass
+
+
+@pytest.mark.parametrize('array', _cartesian_nd_arrays())
+class TestCartesianNdVectorArray(
+    AbstractTestAbstractCartesianNdVectorArray,
+    test_vectors_cartesian.AbstractTestAbstractExplicitCartesianVectorArray,
+):
+
+    @pytest.mark.parametrize(
+        argnames="item",
+        argvalues=[
+            dict(y=0),
+            dict(x=0, y=0),
+            dict(y=slice(None)),
+            dict(y=na.ScalarArrayRange(0, _num_y, axis='y')),
+            dict(x=na.ScalarArrayRange(0, _num_x, axis='x'), y=na.ScalarArrayRange(0, _num_y, axis='y')),
+            dict(
+                y=na.CartesianNdVectorArray(dict(
+                    x=na.ScalarArrayRange(0, _num_y, axis='y'),
+                    y=na.ScalarArrayRange(0, _num_y, axis='y'),
+                ))
+            ),
+            na.ScalarArray.ones(shape=dict(y=_num_y), dtype=bool),
+            np.ones_like(na.CartesianNdVectorArray(dict(x=0, y=0)), dtype=bool, shape=dict(y=_num_y)),
+        ],
+    )
+    @pytest.mark.parametrize(
+        argnames="value",
+        argvalues=[
+            0,
+            na.ScalarUniformRandomSample(-5, 5, dict(y=_num_y)),
+            # na.Cartesian2dVectorUniformRandomSample(-5, 5, shape_random=dict(y=_num_y)),
+        ]
+    )
+    def test__setitem__(
+            self,
+            array: na.ScalarArray,
+            item: dict[str, int | slice | na.ScalarArray] | na.ScalarArray,
+            value: float | na.ScalarArray
+    ):
+        super().test__setitem__(array=array, item=item, value=value)

--- a/named_arrays/_vectors/cartesian/tests/test_vectors_cartesian_nd.py
+++ b/named_arrays/_vectors/cartesian/tests/test_vectors_cartesian_nd.py
@@ -73,7 +73,7 @@ def _cartesian_nd_arrays_2():
     return arrays
 
 
-def _cartesianNd_items() -> list[na.AbstractArray | dict[str, int, slice, na.AbstractArray]]:
+def _cartesian_nd_items() -> list[na.AbstractArray | dict[str, int, slice, na.AbstractArray]]:
     return [
         dict(y=0),
         dict(y=slice(0, 1)),

--- a/named_arrays/_vectors/cartesian/vectors_cartesian.py
+++ b/named_arrays/_vectors/cartesian/vectors_cartesian.py
@@ -33,12 +33,6 @@ class AbstractCartesianVectorArray(
     def type_explicit(self: Self) -> Type[AbstractExplicitCartesianVectorArray]:
         pass
 
-    @property
-    @abc.abstractmethod
-    def cartesian_nd(self):
-        """
-        Convert cartesian vector to instance of :class:`AbstractCartesianNdVectorArray`
-        """
 
     @property
     def length(self: Self) -> na.AbstractScalar:

--- a/named_arrays/_vectors/cartesian/vectors_cartesian.py
+++ b/named_arrays/_vectors/cartesian/vectors_cartesian.py
@@ -36,8 +36,11 @@ class AbstractCartesianVectorArray(
 
     @property
     def length(self: Self) -> na.AbstractScalar:
+        """
+        Return the
+        """
         result = 0
-        entries = self.entries
+        entries = self.cartesian_nd.entries
         for e in entries:
             if entries[e] is not None:
                 result = result + np.square(np.abs(entries[e]))
@@ -47,7 +50,7 @@ class AbstractCartesianVectorArray(
     def __mul__(self: Self, other: na.ArrayLike | u.Unit) -> AbstractExplicitCartesianVectorArray:
         if isinstance(other, u.UnitBase):
             components = self.components
-            result = self.type_explicit()
+            result = self.prototype_vector
             for c in components:
                 result.components[c] = components[c] * other
             return result
@@ -57,7 +60,7 @@ class AbstractCartesianVectorArray(
     def __lshift__(self: Self, other: na.ArrayLike | u.UnitBase) -> AbstractExplicitCartesianVectorArray:
         if isinstance(other, u.UnitBase):
             components= self.components
-            result = self.type_explicit()
+            result = self.prototype_vector
             for c in components:
                 result.components[c] = components[c] << other
             return result
@@ -67,7 +70,7 @@ class AbstractCartesianVectorArray(
     def __truediv__(self: Self, other: na.ArrayLike | u.UnitBase) -> AbstractExplicitCartesianVectorArray:
         if isinstance(other, u.UnitBase):
             components = self.components
-            result = self.type_explicit()
+            result = self.prototype_vector
             for c in components:
                 result.components[c] = components[c] / other
             return result

--- a/named_arrays/_vectors/cartesian/vectors_cartesian.py
+++ b/named_arrays/_vectors/cartesian/vectors_cartesian.py
@@ -36,9 +36,6 @@ class AbstractCartesianVectorArray(
 
     @property
     def length(self: Self) -> na.AbstractScalar:
-        """
-        Return the
-        """
         result = 0
         entries = self.cartesian_nd.entries
         for e in entries:

--- a/named_arrays/_vectors/cartesian/vectors_cartesian_2d.py
+++ b/named_arrays/_vectors/cartesian/vectors_cartesian_2d.py
@@ -72,8 +72,9 @@ class Cartesian2dVectorArray(
     def from_scalar(
             cls: Type[Self],
             scalar: na.AbstractScalar,
+            like: None | na.AbstractExplicitVectorArray = None,
     ) -> Cartesian2dVectorArray:
-        result = super().from_scalar(scalar)
+        result = super().from_scalar(scalar, like=like)
         if result is not NotImplemented:
             return result
 

--- a/named_arrays/_vectors/cartesian/vectors_cartesian_2d.py
+++ b/named_arrays/_vectors/cartesian/vectors_cartesian_2d.py
@@ -55,10 +55,6 @@ class AbstractCartesian2dVectorArray(
         return Cartesian2dVectorArray
 
     @property
-    def cartesian_nd(self):
-        return NotImplementedError
-
-    @property
     def type_matrix(self) -> Type[na.Cartesian2dMatrixArray]:
         return na.Cartesian2dMatrixArray
 
@@ -77,6 +73,10 @@ class Cartesian2dVectorArray(
             cls: Type[Self],
             scalar: na.AbstractScalar,
     ) -> Cartesian2dVectorArray:
+        result = super().from_scalar(scalar)
+        if result is not NotImplemented:
+            return result
+
         return cls(x=scalar, y=scalar)
 
 

--- a/named_arrays/_vectors/cartesian/vectors_cartesian_nd.py
+++ b/named_arrays/_vectors/cartesian/vectors_cartesian_nd.py
@@ -4,7 +4,8 @@ import dataclasses
 import named_arrays as na
 
 __all__ = [
-    "AbstractCartesianNdVectorArray"
+    "AbstractCartesianNdVectorArray",
+    "CartesianNdVectorArray"
 ]
 
 
@@ -37,7 +38,20 @@ class CartesianNdVectorArray(
     def from_scalar(
             cls,
             scalar: na.ScalarLike,
-            components: Sequence[str],
+            like: None | na.AbstractExplicitVectorArray = None,
     ) -> CartesianNdVectorArray:
 
-        pass
+        if like is None:
+            raise ValueError("like argument must be specified for CartesianNdArrays")
+
+        result = super().from_scalar(scalar, like=like)
+        if result is not NotImplemented:
+            return result
+        else:
+            raise ValueError("all implementations of from_scalar return NotImplemented")
+
+
+
+    @classmethod
+    def from_components(cls, components: dict[str, na.ArrayLike]) -> na.CartesianNdMatrixArray:
+        return cls(components)

--- a/named_arrays/_vectors/tests/test_vectors.py
+++ b/named_arrays/_vectors/tests/test_vectors.py
@@ -48,12 +48,7 @@ class AbstractTestAbstractVectorArray(
         array_new = array.astype(dtype)
         for e in array_new.entries:
             entry = array_new.entries[e]
-            if isinstance(entry, na.AbstractVectorArray):
-                for e2 in entry.entries:
-                    entry2 = entry.entries[e2]
-                    assert entry2.dtype == dtype
-            else:
-                entry.dtype == dtype
+            assert entry.dtype == dtype
 
     @pytest.mark.parametrize('unit', [u.mm, u.s])
     def test_to(self, array: na.AbstractVectorArray, unit: None | u.UnitBase):

--- a/named_arrays/_vectors/tests/test_vectors.py
+++ b/named_arrays/_vectors/tests/test_vectors.py
@@ -28,6 +28,26 @@ __all__ = [
 class AbstractTestAbstractVectorArray(
     named_arrays.tests.test_core.AbstractTestAbstractArray,
 ):
+    def test_cartesian_nd(self, array: na.AbstractVectorArray):
+        cartesian_nd = array.cartesian_nd
+        assert isinstance(cartesian_nd, na.AbstractCartesianNdVectorArray)
+        for c in cartesian_nd.components:
+            assert isinstance(na.as_named_array(cartesian_nd.components[c]), na.AbstractScalar)
+
+    def test_from_cartesian_nd(self, array: na.AbstractVectorArray):
+        assert np.all(array.type_explicit.from_cartesian_nd(array.cartesian_nd, like=array) == array)
+
+    def test_matrix(self, array: na.AbstractVectorArray):
+        def _recursive_test(array: na.AbstractMatrixArray):
+            assert isinstance(array, na.AbstractMatrixArray)
+            components = array.components
+            for c in components:
+                component = components[c]
+                if isinstance(component, na.AbstractVectorArray):
+                    _recursive_test(component)
+                else:
+                    assert isinstance(na.as_named_array(component), na.AbstractScalar)
+        _recursive_test(array.matrix)
 
     def test_components(self, array: na.AbstractVectorArray):
         components = array.components

--- a/named_arrays/_vectors/vector_array_functions.py
+++ b/named_arrays/_vectors/vector_array_functions.py
@@ -179,7 +179,7 @@ def array_function_default(
     if initial is not np._NoValue:
         kwargs_base["initial"] = initial
 
-    result = a.type_explicit()
+    result = a.prototype_vector
     for c in components:
         component = na.as_named_array(components[c])
         where_c = components_where[c]
@@ -235,7 +235,7 @@ def array_function_percentile_like(
         keepdims=keepdims,
     )
 
-    result = a.type_explicit()
+    result = a.prototype_vector
     for c in components:
         component = na.as_named_array(components[c])
         shape_c = na.broadcast_shapes(component.shape, shape_base)
@@ -289,7 +289,7 @@ def array_function_arg_reduce(
 
     result = dict()
     for ax in axes_result:
-        result[ax] = a.type_explicit()
+        result[ax] = a.prototype_vector
         for c in components:
             result[ax].components[c] = components_result[c].get(ax, None)
 
@@ -318,7 +318,7 @@ def array_function_fft_like(
         for c in components
     }
 
-    result = a.type_explicit()
+    result = a.prototype_vector
     for c in components:
         result.components[c] = func(
             a=components[c],
@@ -347,7 +347,7 @@ def array_function_fftn_like(
 
     shape_base = {ax: shape_a[ax] for ax in axes}
 
-    result = a.type_explicit()
+    result = a.prototype_vector
     for c in components:
         component = na.as_named_array(components[c])
         result.components[c] = func(
@@ -498,7 +498,7 @@ def array_function_stack_like(
     components_arrays = [a.components for a in arrays]
 
     if out is None:
-        components_out = vector_prototype.type_explicit.from_scalar(out).components
+        components_out = vector_prototype.type_explicit.from_scalar(out, like=vector_prototype).components
     else:
         components_out = out.components
 
@@ -545,7 +545,7 @@ def sort(
 
     shape_base = {ax: shape_a[ax] for ax in axis}
 
-    result = a.type_explicit()
+    result = a.prototype_vector
     for c in components:
         component = na.as_named_array(components[c])
         if any(ax in axis for ax in component.axes):
@@ -584,7 +584,7 @@ def argsort(
 
     shape_base = {ax: shape_a[ax] for ax in axis}
 
-    result = {ax: a.type_explicit() for ax in shape_a}
+    result = {ax: a.prototype_vector for ax in shape_a}
     for c in components:
         component = na.as_named_array(components[c])
         if any(ax in axis for ax in component.axes):

--- a/named_arrays/_vectors/vectors.py
+++ b/named_arrays/_vectors/vectors.py
@@ -88,7 +88,7 @@ class AbstractVectorArray(
             component = self.components[c]
             if isinstance(component, AbstractVectorArray):
                 new_dict[c] = component.matrix
-            elif isinstance(component, na.AbstractScalar):
+            elif isinstance(na.as_named_array(component), na.AbstractScalar):
                 new_dict[c] = component
             else:
                 raise NotImplementedError

--- a/named_arrays/_vectors/vectors.py
+++ b/named_arrays/_vectors/vectors.py
@@ -7,7 +7,6 @@ import numpy as np
 import astropy.units as u
 import named_arrays as na
 
-
 __all__ = [
     'VectorPrototypeT',
     'VectorTypeError',
@@ -37,7 +36,6 @@ class VectorTypeError(TypeError):
 
 
 def _prototype(*arrays: float | u.Quantity | na.AbstractArray) -> na.AbstractVectorArray:
-
     for array in arrays:
         if isinstance(array, na.AbstractVectorArray):
             return array
@@ -49,7 +47,6 @@ def _normalize(
         a: float | u.Quantity | na.AbstractScalar | na.AbstractVectorArray,
         prototype: VectorPrototypeT,
 ) -> VectorPrototypeT:
-
     if isinstance(a, na.AbstractArray):
         if isinstance(a, na.AbstractVectorArray):
             if a.type_abstract == prototype.type_abstract:
@@ -70,7 +67,6 @@ def _normalize(
 class AbstractVectorArray(
     na.AbstractArray
 ):
-
     __named_array_priority__: ClassVar[float] = 100 * na.AbstractScalarArray.__named_array_priority__
 
     @property
@@ -84,6 +80,25 @@ class AbstractVectorArray(
         """
         The corresponding :class:`named_arrays.AbstractMatrixArray` class
         """
+
+    @property
+    def cartesian_nd(self):
+        """
+        Convert cartesian vector to instance of :class:`AbstractCartesianNdVectorArray`
+        """
+        components_new = dict()
+        components = self.components
+        for c in components:
+
+            component = components[c]
+            if isinstance(component, na.AbstractVectorArray):
+                for c2 in component.components:
+                    components_new[f"{c}_{c2}"] = component.components[c2]
+            else:
+                components_new[c] = component
+
+        return na.CartesianNdVectorArray(components_new)
+
 
     @property
     @abc.abstractmethod
@@ -143,7 +158,8 @@ class AbstractVectorArray(
             subok=subok,
             copy=copy,
         )
-        return self.type_explicit.from_components({c: components[c].astype(dtype=dtype[c], **kwargs) for c in components})
+        return self.type_explicit.from_components(
+            {c: components[c].astype(dtype=dtype[c], **kwargs) for c in components})
 
     def to(self: Self, unit: u.UnitBase | dict[str, None | u.UnitBase]) -> AbstractExplicitVectorArray:
         components = self.components
@@ -212,9 +228,9 @@ class AbstractVectorArray(
                 components_item = item.components
                 for c in components_item:
                     item_accumulated = item_accumulated & components_item[c]
-                item = self.type_explicit.from_scalar(item_accumulated)
+                item = self.type_explicit.from_scalar(item_accumulated, like=self)
             elif isinstance(item, na.AbstractScalar):
-                item = self.type_explicit.from_scalar(item)
+                item = self.type_explicit.from_scalar(item, like=self)
             else:
                 return NotImplemented
 
@@ -230,13 +246,13 @@ class AbstractVectorArray(
                     if item[ax].type_abstract == self.type_abstract:
                         item[ax] = item[ax].explicit
                     elif isinstance(item[ax], na.AbstractScalar):
-                        item[ax] = self.type_explicit.from_scalar(item[ax])
+                        item[ax] = self.type_explicit.from_scalar(item[ax], like=self)
                     else:
                         return NotImplemented
                 elif isinstance(item[ax], (int, slice)):
-                    item[ax] = self.type_explicit.from_scalar(item[ax])
+                    item[ax] = self.type_explicit.from_scalar(item[ax], like=self)
                 elif item[ax] is None:
-                    item[ax] = self.type_explicit.from_scalar(item[ax])
+                    item[ax] = self.type_explicit.from_scalar(item[ax], like=self)
                 else:
                     return NotImplemented
 
@@ -260,7 +276,7 @@ class AbstractVectorArray(
         if array.type_abstract == self.type_abstract:
             pass
         elif isinstance(array, na.AbstractArray):
-            array = self.type_explicit.from_scalar(array)
+            array = self.type_explicit.from_scalar(array, like=self)
         else:
             return NotImplemented
         return array._getitem(item)
@@ -276,7 +292,7 @@ class AbstractVectorArray(
             self: Self,
             x1: na.ArrayLike,
             x2: na.ArrayLike,
-            out: tuple[None | na.AbstractExplicitArray] = (None, ),
+            out: tuple[None | na.AbstractExplicitArray] = (None,),
             **kwargs,
     ) -> na.AbstractExplicitArray:
 
@@ -335,7 +351,7 @@ class AbstractVectorArray(
         if func in vector_array_functions.ARRAY_CREATION_LIKE_FUNCTIONS:
             return vector_array_functions.array_function_array_creation_like(func, *args, **kwargs)
 
-        if func in  vector_array_functions.SEQUENCE_FUNCTIONS:
+        if func in vector_array_functions.SEQUENCE_FUNCTIONS:
             return vector_array_functions.array_function_sequence(func, *args, **kwargs)
 
         if func in vector_array_functions.DEFAULT_FUNCTIONS:
@@ -398,15 +414,30 @@ class AbstractExplicitVectorArray(
     ) -> AbstractExplicitVectorArray:
         return cls(**components)
 
+
+
     @classmethod
     @abc.abstractmethod
     def from_scalar(
             cls: Type[Self],
             scalar: na.ScalarLike,
+            like: None | AbstractExplicitVectorArray = None,
     ) -> AbstractExplicitVectorArray:
         """
         Convert a scalar (an instance of :class:`named_arrays.AbstractScalar`) into a vector.
         """
+
+        if like is not None:
+            return like.from_components({c: scalar for c in like.components})
+        else:
+            return NotImplemented
+
+    @classmethod
+    def from_cartesian_nd(
+            cls: Type[Self],
+            cartesian_nd: na.CartesianNdVectorArray,
+    ) -> AbstractExplicitVectorArray:
+        return cls.from_components(cartesian_nd.components)
 
     @property
     def components(self: Self) -> dict[str, na.ArrayLike]:

--- a/named_arrays/_vectors/vectors.py
+++ b/named_arrays/_vectors/vectors.py
@@ -89,11 +89,10 @@ class AbstractVectorArray(
             if isinstance(component, AbstractVectorArray):
                 new_dict[c] = component.matrix
             elif isinstance(component, na.AbstractMatrixArray):
-                return NotImplemented
+                raise NotImplemented
             else:
                 new_dict[c] = component
         return self.type_matrix.from_components(new_dict)
-
 
     @property
     def cartesian_nd(self) -> na.AbstractCartesianNdVectorArray:
@@ -472,8 +471,10 @@ class AbstractExplicitVectorArray(
                 if isinstance(component, na.AbstractVectorArray):
                     nd_key_mod = f"{c}_"
                     sub_dict = {k[len(nd_key_mod):]: v for k, v in nd_components.items() if k.startswith(nd_key_mod)}
-                    components_new[c] = component.type_explicit.from_cartesian_nd(na.CartesianNdMatrixArray(sub_dict),
-                                                                                  like=component)
+                    components_new[c] = component.type_explicit.from_cartesian_nd(
+                        na.CartesianNdMatrixArray(sub_dict),
+                        like=component
+                    )
                 else:
                     components_new[c] = nd_components[c]
 

--- a/named_arrays/_vectors/vectors.py
+++ b/named_arrays/_vectors/vectors.py
@@ -98,7 +98,7 @@ class AbstractVectorArray(
     @property
     def cartesian_nd(self) -> na.AbstractCartesianNdVectorArray:
         """
-        Convert `VectorArray` to instance of :class:`AbstractCartesianNdVectorArray`
+        Convert any instance of :class:`AbstractVectorArray` to an instance of :class:`AbstractCartesianNdVectorArray`
         """
         components_new = dict()
         components = self.components

--- a/named_arrays/_vectors/vectors.py
+++ b/named_arrays/_vectors/vectors.py
@@ -315,9 +315,10 @@ class AbstractVectorArray(
 
         if isinstance(x1, AbstractVectorArray):
             if isinstance(x2, na.AbstractVectorArray):
-                if x1.type_abstract == x2.type_abstract:
-                    components_x1 = x1.cartesian_nd.broadcasted.components
-                    components_x2 = x2.cartesian_nd.broadcasted.components
+                components_x1 = x1.cartesian_nd.broadcasted.components
+                components_x2 = x2.cartesian_nd.broadcasted.components
+
+                if components_x1.keys() == components_x2.keys():
                     result = 0
                     for c in components_x1:
                         component_x1 = na.as_named_array(components_x1[c])

--- a/named_arrays/_vectors/vectors.py
+++ b/named_arrays/_vectors/vectors.py
@@ -89,7 +89,7 @@ class AbstractVectorArray(
             if isinstance(component, AbstractVectorArray):
                 new_dict[c] = component.matrix
             elif isinstance(component, na.AbstractMatrixArray):
-                raise NotImplemented
+                raise NotImplementedError
             else:
                 new_dict[c] = component
         return self.type_matrix.from_components(new_dict)

--- a/named_arrays/_vectors/vectors.py
+++ b/named_arrays/_vectors/vectors.py
@@ -434,10 +434,30 @@ class AbstractExplicitVectorArray(
 
     @classmethod
     def from_cartesian_nd(
-            cls: Type[Self],
+            cls: AbstractExplicitVectorArray,
             cartesian_nd: na.CartesianNdVectorArray,
+            like: None | AbstractExplicitVectorArray = None,
     ) -> AbstractExplicitVectorArray:
-        return cls.from_components(cartesian_nd.components)
+
+        if like is None:
+            components_new = cartesian_nd.components
+
+        else:
+            nd_components = cartesian_nd.components
+            components_new = {}
+            components = like.components
+            for c in components:
+
+                component = components[c]
+                if isinstance(component, na.AbstractVectorArray):
+                    secondary_components = {}
+                    for c2 in component.components:
+                        secondary_components[c2] = nd_components[f"{c}_{c2}"]
+                    components_new[c] = component.type_explicit.from_components(secondary_components)
+                else:
+                    components_new[c] = component
+
+        return cls.from_components(components_new)
 
     @property
     def components(self: Self) -> dict[str, na.ArrayLike]:

--- a/named_arrays/_vectors/vectors.py
+++ b/named_arrays/_vectors/vectors.py
@@ -94,9 +94,6 @@ class AbstractVectorArray(
                 new_dict[c] = component
         return self.type_matrix.from_components(new_dict)
 
-    @property
-    def vector(self):
-        return self
 
     @property
     def cartesian_nd(self):

--- a/named_arrays/_vectors/vectors.py
+++ b/named_arrays/_vectors/vectors.py
@@ -82,7 +82,7 @@ class AbstractVectorArray(
         """
 
     @property
-    def matrix(self):
+    def matrix(self) -> na.AbstractMatrixArray:
         new_dict = {}
         for c in self.components:
             component = self.components[c]
@@ -96,7 +96,7 @@ class AbstractVectorArray(
 
 
     @property
-    def cartesian_nd(self):
+    def cartesian_nd(self) -> na.AbstractCartesianNdVectorArray:
         """
         Convert `VectorArray` to instance of :class:`AbstractCartesianNdVectorArray`
         """
@@ -147,7 +147,7 @@ class AbstractVectorArray(
         return self.type_explicit.from_components(components_result)
 
     @property
-    def prototype_vector(self):
+    def prototype_vector(self) -> na.AbstractExplicitVectorArray:
         """
         Return vector of same type with all components zeroed.
         """

--- a/named_arrays/_vectors/vectors.py
+++ b/named_arrays/_vectors/vectors.py
@@ -101,7 +101,7 @@ class AbstractVectorArray(
     @property
     def cartesian_nd(self):
         """
-        Convert cartesian vector to instance of :class:`AbstractCartesianNdVectorArray`
+        Convert `VectorArray` to instance of :class:`AbstractCartesianNdVectorArray`
         """
         components_new = dict()
         components = self.components
@@ -130,7 +130,7 @@ class AbstractVectorArray(
         """
         The scalar entries that compose this object.
         """
-        return self.components
+        return self.cartesian_nd.components
 
     @property
     def value(self) -> na.AbstractExplicitVectorArray:
@@ -342,7 +342,6 @@ class AbstractVectorArray(
                         component_x1 = na.as_named_array(components_x1[c])
                         component_x2 = na.as_named_array(components_x2[c])
                         result = np.add(result, np.matmul(component_x1, component_x2), out=out)
-                        # result = x1.type_explicit.from_cartesian_nd(result, like=x1)
                 else:
                     result = NotImplemented
             elif isinstance(na.as_named_array(x2), na.ScalarArray):
@@ -459,15 +458,15 @@ class AbstractExplicitVectorArray(
     @classmethod
     def from_cartesian_nd(
             cls: AbstractExplicitVectorArray,
-            cartesian_nd: na.CartesianNdVectorArray,
+            array: na.CartesianNdVectorArray,
             like: None | AbstractExplicitVectorArray = None,
     ) -> AbstractExplicitVectorArray:
 
         if like is None:
-            components_new = cartesian_nd.components
+            components_new = array.components
 
         else:
-            nd_components = cartesian_nd.components
+            nd_components = array.components
             components_new = {}
             components = like.components
             for c in components:

--- a/named_arrays/_vectors/vectors.py
+++ b/named_arrays/_vectors/vectors.py
@@ -433,7 +433,7 @@ class AbstractExplicitVectorArray(
         """
 
         if like is not None:
-            return like.from_components({c: scalar for c in like.components})
+            return like.type_explicit.from_components({c: scalar for c in like.components})
         else:
             return NotImplemented
 

--- a/named_arrays/_vectors/vectors.py
+++ b/named_arrays/_vectors/vectors.py
@@ -88,10 +88,12 @@ class AbstractVectorArray(
             component = self.components[c]
             if isinstance(component, AbstractVectorArray):
                 new_dict[c] = component.matrix
-            elif isinstance(component, na.AbstractMatrixArray):
-                raise NotImplementedError
-            else:
+            elif isinstance(component, na.AbstractScalar):
                 new_dict[c] = component
+            else:
+                raise NotImplementedError
+
+
         return self.type_matrix.from_components(new_dict)
 
     @property

--- a/named_arrays/_vectors/vectors_position.py
+++ b/named_arrays/_vectors/vectors_position.py
@@ -55,7 +55,11 @@ class PositionVectorArray(
     def from_scalar(
             cls: Type[Self],
             scalar: na.AbstractScalar,
+            like: None | na.AbstractExplicitVectorArray = None,
     ) -> PositionVectorArray:
+        result = super().from_scalar(scalar, like=like)
+        if result is not NotImplemented:
+            return result
         return cls(Position=scalar)
 
 

--- a/named_arrays/_vectors/vectors_spectral.py
+++ b/named_arrays/_vectors/vectors_spectral.py
@@ -39,11 +39,6 @@ class AbstractSpectralVectorArray(
         return SpectralVectorArray
 
     @property
-    def cartesian_nd(self):
-        return NotImplementedError
-
-
-    @property
     def type_matrix(self) -> Type[na.SpectralMatrixArray]:
         return na.SpectralMatrixArray
 
@@ -60,7 +55,11 @@ class SpectralVectorArray(
     def from_scalar(
             cls: Type[Self],
             scalar: na.AbstractScalar,
+            like: None | na.AbstractExplicitVectorArray = None,
     ) -> SpectralVectorArray:
+        result = super().from_scalar(scalar, like=like)
+        if result is not NotImplemented:
+            return result
         return cls(wavelength=scalar)
 
 

--- a/named_arrays/_vectors/vectors_spectral_position.py
+++ b/named_arrays/_vectors/vectors_spectral_position.py
@@ -28,11 +28,6 @@ class AbstractSpectralPositionVectorArray(
         return SpectralPositionVectorArray
 
     @property
-    def cartesian_nd(self):
-        return NotImplementedError
-
-
-    @property
     def type_matrix(self) -> Type[na.SpectralPositionMatrixArray]:
         return na.SpectralPositionMatrixArray
 
@@ -48,7 +43,11 @@ class SpectralPositionVectorArray(
     def from_scalar(
             cls: Type[Self],
             scalar: na.AbstractScalar,
+            like: None | na.AbstractExplicitVectorArray = None,
     ) -> SpectralPositionVectorArray:
+        result = super().from_scalar(scalar, like=like)
+        if result is not NotImplemented:
+            return result
         return cls(wavelength=scalar, position=scalar)
 
 

--- a/named_arrays/tests/test_core.py
+++ b/named_arrays/tests/test_core.py
@@ -263,7 +263,12 @@ class AbstractTestAbstractArray(
         assert isinstance(array_copy, na.AbstractArray)
         assert dataclasses.is_dataclass(array_copy)
         for field in dataclasses.fields(array_copy):
-            assert np.all(getattr(array, field.name) == getattr(array_copy, field.name))
+            attr = getattr(array, field.name)
+            attr_copy = getattr(array_copy, field.name)
+            if isinstance(attr, dict):
+                assert [np.all(attr[key] == attr_copy[key] for key in attr.keys())]
+            else:
+                assert np.all(attr == attr_copy)
 
     @abc.abstractmethod
     def test__getitem__(

--- a/named_arrays/tests/test_core.py
+++ b/named_arrays/tests/test_core.py
@@ -266,7 +266,7 @@ class AbstractTestAbstractArray(
             attr = getattr(array, field.name)
             attr_copy = getattr(array_copy, field.name)
             if isinstance(attr, dict):
-                assert [np.all(attr[key] == attr_copy[key] for key in attr.keys())]
+                assert [np.all(attr[key] == attr_copy[key] for key in attr)]
             else:
                 assert np.all(attr == attr_copy)
 


### PR DESCRIPTION
The addition of SpectralPositionVectorArray and SpectralPositionMatrixArray prompted the addition of cartesian_nd property and from_cartesian_nd method.  These allow for nested arrays to be flattened for operating on, and reshaped into their original form. 